### PR TITLE
[sailfish-setup] Make sure that master user / device owner exists. Contributes to JB#48029

### DIFF
--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -6,9 +6,13 @@ Group:      System/Base
 License:    Public Domain
 Url:        https://github.com/sailfishos/sailfish-setup
 Source0:    %{name}-%{version}.tar.bz2
+BuildArch:  noarch
 
 Requires: setup
 Requires(pre): setup
+# Some mandatory groups are created by systemd like input
+Requires: systemd
+Requires(pre): systemd
 Requires(pre): /usr/bin/getent
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
@@ -27,6 +31,15 @@ groupadd -rf sailfish-radio || :
 groupadd -rf sailfish-actdead || :
 if ! getent passwd sailfish-actdead >/dev/null ; then
     useradd -r -g sailfish-actdead -d / -s /sbin/nologin sailfish-actdead || :
+fi
+
+# TODO : This should be moved to the first boot (JB#48049)
+# Make sure that device owner exists.
+groupadd -fg 100000 nemo || :
+if ! getent passwd nemo >/dev/null ; then
+    # Requirements - source component in brackets:
+    # video for display (setup), input input devices (systemd), audio for itself (setup)
+    useradd -g nemo -G "video,input,audio" -u 100000 -m nemo || :
 fi
 
 groupadd -rf sailfish-system || :


### PR DESCRIPTION
@krnlyng @saukko review?

This could be improved so that we'd test if droid.ids exists and read groups from there for nemo. Referring to https://github.com/mer-hybris/droid-hal-device/pull/246

Further, sailfish-setup should be among the first installed packages I'd say right after "setup" package.