### PR TITLE
Add hard dependency to hardware-adaptation-setup.

### DIFF
--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -16,7 +16,7 @@ Requires(pre): systemd
 Requires(pre): /usr/bin/getent
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
-Recommends: hardware-adaptation-setup
+Requires: hardware-adaptation-setup
 
 %description
 %{summary}.


### PR DESCRIPTION
This will ensure that adapatation setup package will be installed
at the early stage. Normally droid-hal packages will provide this.

https://github.com/mer-hybris/droid-hal-device

If there is no such a package available, some adaptation package
need to provide hardware-adaptation-setup.