### PR TITLE
Add groups for phone use permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Groups that this package defines are listed below.
     MDM APIs.
 - sailfish-radio
   - For processes that need to be able to access mobile network related APIs.
+- sailfish-phone
+  - For users that need to be able to make calls.
+- sailfish-messages
+  - For users that need to be able to send SMS and MMS.
 - sailfish-alarms
   - For users that need to be able to access shared alarm events.
 - sailfish-datetime

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Sailfish Setup
 ==============
 
-This package is responsible for creating Sailfish OS specific users and/or groups on which
-other packages could depend on.
+This package is responsible for creating Sailfish OS specific users
+and groups on which other packages may depend on.
 
 Usage
 -----
@@ -16,6 +16,7 @@ Users
 Users that this package defines are listed below.
 
 - sailfish-mdm
+- sailfish-actdead
 
 Groups
 ------
@@ -24,19 +25,23 @@ Groups that this package defines are listed below.
 - privileged
   - For processes that need to be able to access privileged data.
 - sailfish-system
-  - For users and processes that need to be able to control the device.
+  - For users that need to be able to control the device settings.
     Device owner belongs to this group.
 - sailfish-mdm
-  - For processes that need to be able to access MDM APIs.
+  - For sailfish-mdm user and processes that need to be able to access
+    MDM APIs.
 - sailfish-radio
   - For processes that need to be able to access mobile network related APIs.
 - sailfish-alarms
-  - For processes that need to be able to access shared alarm events.
+  - For users that need to be able to access shared alarm events.
 - sailfish-datetime
-  - For processes that need to be able to modify clock settings.
+  - For users that need to be able to modify clock settings.
 - timed
-  - For timed process, required for changing system default timezone
+  - For users and timed process, required to change system default
+    timezone.
+- sailfish-actdead
+  - For sailfish-actdead user.
 
 Default system (SYSTEM_GROUPS) and additional user (USER_GROUPS) groups are
-stored in the file /usr/share/sailfish-setup/group.ids, system user will be created during
-boot if it does not already exist.
+stored in the file /usr/share/sailfish-setup/group.ids, system user will be
+created during boot if it does not already exist.

--- a/group.ids
+++ b/group.ids
@@ -1,2 +1,2 @@
-SYSTEM_GROUPS sailfish-system,sailfish-datetime,timed,system,ssu
+SYSTEM_GROUPS sailfish-system,sailfish-datetime,timed,ssu
 USER_GROUPS video,input,audio,users,sailfish-alarms,sailfish-phone,sailfish-messages,bluetooth

--- a/group.ids
+++ b/group.ids
@@ -1,2 +1,2 @@
 SYSTEM_GROUPS sailfish-system,sailfish-datetime,timed,system,ssu
-USER_GROUPS video,input,audio,users,oneshot,sailfish-alarms,bluetooth,graphics,camera,media,media_rw,mtp,inet
+USER_GROUPS video,input,audio,users,sailfish-alarms,sailfish-phone,sailfish-messages,bluetooth

--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -2,7 +2,6 @@ Name:       sailfish-setup
 Summary:    Sailfish Setup
 Version:    0.1.0
 Release:    1
-Group:      System/Base
 License:    Public Domain
 Url:        https://github.com/sailfishos/sailfish-setup
 Source0:    %{name}-%{version}.tar.bz2
@@ -20,7 +19,8 @@ Requires(pre): /usr/sbin/usermod
 Recommends: hardware-adaptation-setup
 
 %description
-%{summary}.
+This package is responsible for creating Sailfish OS specific users
+and groups on which other packages may depend on.
 
 %pre
 groupadd -rf privileged || :
@@ -33,8 +33,6 @@ groupadd -rf sailfish-actdead || :
 if ! getent passwd sailfish-actdead >/dev/null ; then
     useradd -r -g sailfish-actdead -d / -s /sbin/nologin sailfish-actdead || :
 fi
-
-groupadd -rf oneshot || :
 
 groupadd -rf sailfish-system || :
 usermod -a -G sailfish-system sailfish-mdm || :

--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -24,11 +24,14 @@ and groups on which other packages may depend on.
 
 %pre
 groupadd -rf privileged || :
+
 groupadd -rf sailfish-mdm || :
 if ! getent passwd sailfish-mdm >/dev/null ; then
     useradd -r -g sailfish-mdm -G privileged -d / -s /sbin/nologin sailfish-mdm || :
 fi
+
 groupadd -rf sailfish-radio || :
+
 groupadd -rf sailfish-actdead || :
 if ! getent passwd sailfish-actdead >/dev/null ; then
     useradd -r -g sailfish-actdead -d / -s /sbin/nologin sailfish-actdead || :
@@ -44,6 +47,10 @@ groupadd -rf sailfish-alarms || :
 groupadd -rf sailfish-datetime || :
 
 groupadd -rf timed || :
+
+groupadd -rf sailfish-phone || :
+
+groupadd -rf sailfish-messages || :
 
 %prep
 %setup -q


### PR DESCRIPTION
Add sailfish-calls and sailfish-messages groups for calls and SMSs respectively. Defaults to users having those permissions. Also clarify group definitions for existing groups and clean up hardware specific groups from USER_GROUPS.