### PR TITLE
[sailfish-setup] Add missing users and groups. Contributes to JB#46282

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ Users
 -----
 Users that this package defines are listed below.
 
+- privileged
 - sailfish-mdm
 - sailfish-actdead
+- sailfish-code
+- sailfish-fingerprint
 
 Groups
 ------
@@ -41,10 +44,11 @@ Groups that this package defines are listed below.
 - sailfish-datetime
   - For users that need to be able to modify clock settings.
 - timed
-  - For users and timed process, required to change system default
-    timezone.
+  - For users and timed process, required to change system default timezone.
 - sailfish-actdead
   - For sailfish-actdead user.
+- sailfish-authentication
+  - For device lock.
 
 Default system (SYSTEM_GROUPS) and additional user (USER_GROUPS) groups are
 stored in the file /usr/share/sailfish-setup/group.ids, system user will be

--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -24,6 +24,9 @@ and groups on which other packages may depend on.
 
 %pre
 groupadd -rf privileged || :
+if ! getent passwd privileged >/dev/null ; then
+    useradd -r -g privileged  -d / -s /sbin/nologin privileged || :
+fi
 
 groupadd -rf sailfish-mdm || :
 if ! getent passwd sailfish-mdm >/dev/null ; then
@@ -51,6 +54,14 @@ groupadd -rf timed || :
 groupadd -rf sailfish-phone || :
 
 groupadd -rf sailfish-messages || :
+
+groupadd -rf sailfish-authentication || :
+if ! getent passwd sailfish-code >/dev/null ; then
+    useradd -r -g sailfish-authentication -d / -s /sbin/nologin sailfish-code || :
+fi
+if ! getent passwd sailfish-fingerprint >/dev/null ; then
+    useradd -r -g sailfish-authentication -d / -s /sbin/nologin sailfish-fingerprint || :
+fi
 
 %prep
 %setup -q


### PR DESCRIPTION
These users and groups were scattered around packages.