### PR TITLE
[sailfish-setup] Account provider groups. Contributes to JB#51329

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 installroot
 RPMS
+*.list

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Sailfish Setup
 ==============
 
 This package is responsible for creating Sailfish OS specific users
-and groups on which other packages may depend on.
+and groups which other packages may depend on.
 
 Usage
 -----
@@ -50,6 +50,19 @@ Groups that this package defines are listed below.
 - sailfish-authentication
   - For device lock.
 
-Default system (SYSTEM_GROUPS) and additional user (USER_GROUPS) groups are
-stored in the file /usr/share/sailfish-setup/group.ids, system user will be
-created during boot if it does not already exist.
+Device owner's (SYSTEM\_GROUPS) and additional users' (USER\_GROUPS and
+USER\_GROUPS\_DEFAULT) groups are stored in file
+***/usr/share/sailfish-setup/group_ids.env***. Device owner will be created
+during boot if it does not already exist.
+
+Account groups
+--------------
+Account provider group specifies all users that are allowed to create an account
+for respective provider. They are not created inside this package but instead
+they have a specific format and are created by account packages themselves.
+
+There is a script for managing these groups. If you want that to limit an
+account provider to arbitrary users, see ***scripts/manage-groups.sh*** script
+for more instructions. If account provider is limited to a group that is already
+listed in this file instead, you don't need to create account provider group but
+you should still specify the needed group within account provider configuration.

--- a/group.ids
+++ b/group.ids
@@ -1,2 +1,0 @@
-SYSTEM_GROUPS sailfish-system,sailfish-datetime,timed,ssu
-USER_GROUPS video,input,audio,users,sailfish-alarms,sailfish-phone,sailfish-messages,bluetooth

--- a/group_ids.env
+++ b/group_ids.env
@@ -1,0 +1,3 @@
+SYSTEM_GROUPS=sailfish-system,sailfish-datetime,timed,ssu,sailfish-alarms,sailfish-phone,sailfish-messages
+USER_GROUPS=video,input,audio,users,bluetooth
+USER_GROUPS_DEFAULT=sailfish-alarms,sailfish-phone,sailfish-messages

--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -12,10 +12,19 @@ Requires(pre): setup
 # Some mandatory groups are created by systemd like input
 Requires: systemd
 Requires(pre): systemd
+# Commands used by scriptlets
 Requires(pre): /usr/bin/getent
 Requires(pre): /usr/sbin/groupadd
 Requires(pre): /usr/sbin/useradd
 Requires(pre): /usr/sbin/usermod
+# Needed by manage-groups.sh
+Requires: /usr/bin/getent
+Requires: /usr/sbin/groupadd
+Requires: /usr/sbin/groupdel
+Requires: /usr/sbin/usermod
+Requires: coreutils
+Requires: grep
+# Other
 Recommends: hardware-adaptation-setup
 
 %description
@@ -69,8 +78,10 @@ fi
 %build
 
 %install
-install -D group.ids $RPM_BUILD_ROOT%{_datadir}/%{name}/group.ids
+install -D group_ids.env $RPM_BUILD_ROOT%{_datadir}/%{name}/group_ids.env
+install -D scripts/manage-groups.sh $RPM_BUILD_ROOT%{_libexecdir}/manage-groups
 
 %files
 %defattr(-,root,root,-)
 %{_datadir}/%{name}
+%{_libexecdir}/manage-groups

--- a/scripts/manage-groups.sh
+++ b/scripts/manage-groups.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+# Copyright (c) 2020 Open Mobile Platform LLC.
+#
+# Manages groups created within packages.
+# Currently only groups for accounts may be managed with this.
+#
+# Use like this in spec file to create a group named account-provider_name for
+# account provider named provider_name (substitute your own provider name):
+#
+#     Requires(post): %{_libexecdir}/manage-groups
+#     Requires(postun): %{_libexecdir}/manage-groups
+#
+#     %post
+#     %{_libexecdir}/manage-groups add account-provider_name || :
+#
+#     %postun
+#     if [ "$1" -eq 0 ]; then
+#         %{_libexecdir}/manage-groups remove account-provider_name || :
+#     fi
+
+usage() { # $1: invalid argument or an error message
+    echo "Invalid arguments: $1"
+    echo "$0 add|remove <group>"
+    echo "or"
+    echo "$0 check <uid>"
+    exit 1
+}
+
+_group_name_check() { # $1: group name
+    if [ "$1" = "${1#account-}" ]
+    then
+        echo "Currently only groups with account- prefix may be managed"
+        exit 2
+    fi
+}
+
+_get_flag_file() { # $1: group name or group prefix
+    case "${1%%-*}" in
+        "account") echo "/var/lib/sailfish-mdm/accounts-managed" ;;
+        "*") echo "/doesnotexist" ;;
+    esac
+}
+
+_add_users_to_managed_group() { # $1: usernames, $2: group name
+    if [ ! -e "$(_get_flag_file "$1")" ]
+    then
+        for username in $(echo "$1" | tr , " ")
+        do
+            usermod -a -G "$2" "$username"
+        done
+    fi
+}
+
+add_group() { # $1: group name
+    _group_name_check "$1"
+    groupadd -r "$1"
+    _add_users_to_managed_group "$(getent group users | cut -d: -f4)" "$1"
+}
+
+remove_group() { # $1: group name
+    _group_name_check "$1"
+    groupdel "$1"
+}
+
+_add_to_groups() { # $1: username, $2: new groups
+    # Try to add all at once
+    if ! usermod -a -G "$2" "$1"
+    then
+        # In case of a failure add one by one and log errors
+        for group in $(echo "$2" | tr , " ")
+        do
+            if ! usermod -a -G "$group" "$1"
+            then
+                # Let's be loud about the error
+                echo "ERROR: Could not add $1 to $group, the system may be broken"
+            fi
+        done
+    fi
+}
+
+_add_to_managed_groups() { # $1: username, $2: prefix
+    if [ -e "$(_get_flag_file "$2")" ]
+    then
+        echo "${2}-* groups are managed, not touching"
+    else
+        _add_to_groups "$1" "$(grep -oE "^${2}-[^:]+" "/etc/group" | head -c -1 | tr '\n' ,)"
+    fi
+}
+
+check_user() { # $1: uid
+    # shellcheck source=group_ids.env
+    . "/usr/share/sailfish-setup/group_ids.env"
+    username=$(getent passwd "$1" | cut -d: -f1)
+    if [ "$1" -eq "100000" ] # checking for device owner
+    then
+        _add_to_groups "$username" "$SYSTEM_GROUPS"
+    fi
+    # everyone
+    _add_to_groups "$username" "$USER_GROUPS"
+    _add_to_managed_groups "$username" "account"
+}
+
+if [ "$#" -lt "2" ]
+then
+    usage "Not enough arguments"
+elif [ "$#" -gt "2" ]
+then
+    usage "Too many arguments"
+fi
+
+case "$1" in
+    "add") add_group "$2" ;;
+    "remove") remove_group "$2" ;;
+    "check") check_user "$2" ;;
+    *) usage "$1" ;;
+esac
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Document account groups in README and add manage-groups script.