### PR TITLE
[sailfish-setup] Provide manage-groups. Contributes to JB#51329

### DIFF
--- a/rpm/sailfish-setup.spec
+++ b/rpm/sailfish-setup.spec
@@ -26,6 +26,7 @@ Requires: coreutils
 Requires: grep
 # Other
 Recommends: hardware-adaptation-setup
+Provides: %{_libexecdir}/manage-groups
 
 %description
 This package is responsible for creating Sailfish OS specific users


### PR DESCRIPTION
RPM doesn't automatically infer this provides.