### PR TITLE
[sailjail-setup] Use correct argument in manage-groups.sh. Fixes JB#53485

### DIFF
--- a/scripts/manage-groups.sh
+++ b/scripts/manage-groups.sh
@@ -42,7 +42,7 @@ _get_flag_file() { # $1: group name or group prefix
 }
 
 _add_users_to_managed_group() { # $1: usernames, $2: group name
-    if [ ! -e "$(_get_flag_file "$1")" ]
+    if [ ! -e "$(_get_flag_file "$2")" ]
     then
         for username in $(echo "$1" | tr , " ")
         do


### PR DESCRIPTION
Use $2 (group name) instead of $1 (list of users) when checking for flag
file in _add_users_to_managed_group(). This corrects behaviour when MDM
has set the flag file and manages users instead of relying on automation
using this script.